### PR TITLE
CI: Cache BTFGen

### DIFF
--- a/.github/workflows/inspektor-gadget.yml
+++ b/.github/workflows/inspektor-gadget.yml
@@ -227,6 +227,27 @@ jobs:
         registry: ${{ env.REGISTRY }}
         container-image: ${{ env.CONTAINER_REPO }}
         co-re: ${{ matrix.type == 'core' }}
+    - name: Get btfhub-archive last commmit
+      id: get-btfhub-head
+      run: |
+        echo "head=$(git ls-remote https://github.com/aquasecurity/btfhub-archive/ HEAD | cut -f1)" >> $GITHUB_OUTPUT
+      shell: bash
+    - name: Cache BTFGen
+      id: cache-btfgen
+      uses: actions/cache@v3.0.11
+      with:
+        path: hack/btfs
+        # key is composed by
+        # - arch: amd64 or arm64
+        # - lastest commit of btfhub
+        # - hash of all bpf objects
+        key: btfgen-${{ matrix.platform }}-${{ steps.get-btfhub-head.outputs.head }}-${{ hashFiles('pkg/gadgets/**/*.o') }}
+    - name: BTFGen
+      if: ${{ steps.cache-btfgen.outputs.cache-hit != 'true' }}
+      run: |
+          ./tools/getbtfhub.sh
+          make btfgen BPFTOOL=$HOME/btfhub/tools/bin/bpftool.x86_64 \
+              BTFHUB_ARCHIVE=$HOME/btfhub-archive/ OUTPUT=$GITHUB_WORKSPACE/hack/btfs -j$(nproc)
     # we are using cache-to mode=min (default) implying that only final image layers are cached, using cache
     # mode=max results in builder image layer of ~7GB because of btfhub files in a layer, which is too
     # large (gloabal limit 10GB) to work with GH caches. (TODO: if we can work with mode=max in future?)
@@ -235,8 +256,6 @@ jobs:
       with:
         context: /home/runner/work/inspektor-gadget/inspektor-gadget/
         file: /home/runner/work/inspektor-gadget/inspektor-gadget/Dockerfiles/gadget-${{ matrix.type }}.Dockerfile
-        build-args: |
-          ENABLE_BTFGEN=true
         outputs: type=docker,dest=/tmp/gadget-container-image-${{ matrix.type }}-${{ matrix.os }}-${{ matrix.platform }}.tar
         tags: ${{ steps.set-repo-determine-image-tag.outputs.container-repo }}:${{ steps.set-repo-determine-image-tag.outputs.image-tag }}
         cache-from: type=local,src=/tmp/.buildx-cache
@@ -257,8 +276,6 @@ jobs:
       with:
         context: /home/runner/work/inspektor-gadget/inspektor-gadget/
         file: /home/runner/work/inspektor-gadget/inspektor-gadget/Dockerfiles/gadget-${{ matrix.type }}.Dockerfile
-        build-args: |
-          ENABLE_BTFGEN=true
         outputs: type=registry,name=${{ steps.set-repo-determine-image-tag.outputs.container-repo }},push=true,push-by-digest=true
         cache-from: type=local,src=/tmp/.buildx-cache-new
         platforms: ${{ matrix.os }}/${{ matrix.platform }}

--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,10 @@
 # Downloaded binaries
 bin/
 
+# BTF files
+hack/btfs/*
+!hack/btfs/README.md
+
 # Build artifacts
 *.o
 # keep all bpf objects generated with bpf2go

--- a/Dockerfiles/gadget-core.Dockerfile.dockerignore
+++ b/Dockerfiles/gadget-core.Dockerfile.dockerignore
@@ -2,6 +2,7 @@
 !go.mod
 !go.sum
 !gadget-container
+!hack/btfs
 !pkg
 !tools
 !Makefile*

--- a/Dockerfiles/gadget-default.Dockerfile
+++ b/Dockerfiles/gadget-default.Dockerfile
@@ -11,9 +11,6 @@ ARG BCC="quay.io/kinvolk/bcc:b3b9bd12109fefce4dc31314cecdaeac5bf0d83e-focal-rele
 FROM ${BCC} as bcc
 FROM --platform=${BUILDPLATFORM} ${BUILDER_IMAGE} as builder
 
-ARG ENABLE_BTFGEN=false
-ENV ENABLE_BTFGEN=${ENABLE_BTFGEN}
-
 ARG TARGETARCH
 # We need a cross compiler and libraries for TARGETARCH due to CGO.
 RUN set -ex; \
@@ -30,14 +27,6 @@ RUN set -ex; \
 		apt-get install -y gcc-aarch64-linux-gnu; \
 	fi
 
-# Download BTFHub files
-COPY ./tools /btf-tools
-RUN set -ex; mkdir -p /tmp/btfs && \
-	if [ "$ENABLE_BTFGEN" = true ]; then \
-		cd /btf-tools && \
-		./getbtfhub.sh; \
-	fi
-
 # Cache go modules so they won't be downloaded at each build
 COPY go.mod go.sum /gadget/
 RUN cd /gadget && go mod download
@@ -49,14 +38,6 @@ RUN cd /gadget/gadget-container && \
 		export CC=aarch64-linux-gnu-gcc; \
 	fi; \
 	make -j$(nproc) TARGET_ARCH=${TARGETARCH} gadget-container-deps
-
-# Execute BTFGen
-RUN set -ex; \
-	if [ "$ENABLE_BTFGEN" = true ]; then \
-		cd /gadget && \
-		make btfgen BPFTOOL=/tmp/btfhub/tools/bin/bpftool.x86_64 \
-			BTFHUB_ARCHIVE=/tmp/btfhub-archive/ OUTPUT=/tmp/btfs/ -j$(nproc); \
-	fi
 
 # Main gadget image
 
@@ -90,7 +71,7 @@ COPY gadget-container/hooks/nri/conf.json /opt/hooks/nri/
 ## Hooks Ends
 
 # BTF files
-COPY --from=builder /tmp/btfs /btfs/
+COPY hack/btfs /btfs/
 
 # Mitigate https://github.com/kubernetes/kubernetes/issues/106962.
 RUN rm -f /var/run

--- a/Dockerfiles/gadget-default.Dockerfile.dockerignore
+++ b/Dockerfiles/gadget-default.Dockerfile.dockerignore
@@ -2,6 +2,7 @@
 !go.mod
 !go.sum
 !gadget-container
+!hack/btfs
 !pkg
 !tools
 !Makefile*

--- a/Makefile
+++ b/Makefile
@@ -125,8 +125,13 @@ GADGET_CONTAINERS = \
 gadget-container-all: $(GADGET_CONTAINERS)
 
 gadget-%-container:
-	docker buildx build -t $(CONTAINER_REPO):$(IMAGE_TAG)$(if $(findstring core,$*),-core,) -f Dockerfiles/gadget-$*.Dockerfile \
-		--build-arg ENABLE_BTFGEN=$(ENABLE_BTFGEN) .
+	if $(ENABLE_BTFGEN) == "true" ; then \
+		./tools/getbtfhub.sh && \
+		$(MAKE) -f Makefile.btfgen BPFTOOL=$(HOME)/btfhub/tools/bin/bpftool.$(uname -m) \
+			BTFHUB_ARCHIVE=$(HOME)/btfhub-archive/ OUTPUT=hack/btfs/ -j$(nproc); \
+	fi
+	docker buildx build -t $(CONTAINER_REPO):$(IMAGE_TAG)$(if $(findstring core,$*),-core,) \
+		-f Dockerfiles/gadget-$*.Dockerfile .
 
 push-gadget-%-container:
 	docker push $(CONTAINER_REPO):$(IMAGE_TAG)$(if $(findstring core,$*),-core,)

--- a/hack/btfs/README.md
+++ b/hack/btfs/README.md
@@ -1,0 +1,1 @@
+NOTE: This empty folder is required to build the gadget container. Don't remove it.

--- a/tools/getbtfhub.sh
+++ b/tools/getbtfhub.sh
@@ -2,5 +2,13 @@
 
 set -e
 
-git clone --depth 1 https://github.com/aquasecurity/btfhub /tmp/btfhub
-git clone --depth 1 https://github.com/aquasecurity/btfhub-archive/ /tmp/btfhub-archive/
+# Don't clone the repo to /tmp because on some systems it's mounted as tempfs and will require a lot
+# of RAM.
+
+if [ ! -d $HOME/btfhub ]; then
+	git clone --depth 1 https://github.com/aquasecurity/btfhub $HOME/btfhub
+fi
+
+if [ ! -d $HOME/btfhub-archive/ ]; then
+	git clone --depth 1 https://github.com/aquasecurity/btfhub-archive/ $HOME/btfhub-archive/
+fi


### PR DESCRIPTION
BTFGen takes a lot of time to execute because it has to:
1. clone the btfhub-archive repo (some GBs)
2. uncompress all files from btfhub-archive
3. run btfgen for all btf files uncompressed above

It's only required to run this command when the bpf objects are changed or new BTF files are pushed to btfhub-archive.

This commit modifies the building system to use the Github actions to cache the generated BTF files. The changes done here are:
1. Execute btfgen outside the building container: It's hard to extract the BTF files from the container to save them in the cache.
2. Define a cache for the btf files: It uses as key the architecture, the latest commit of btfhub-archive and the hash of all bpf objects.

# [Title: describe the change in one sentence]

[ describe the change in 1 - 3 paragraphs ]

## How to use

[ describe what reviewers need to do in order to validate this PR ]

## Testing done

[Describe the testing you have done before submitting this PR. Please include both the commands you issued as well as the output you got.]
