### PR TITLE
CI: Cleanup citest tags

### DIFF
--- a/.github/workflows/cleanup.yml
+++ b/.github/workflows/cleanup.yml
@@ -1,0 +1,34 @@
+name: Inspektor Gadget Cleanup
+on: delete
+env:
+  GO_VERSION: 1.21.3
+  REGISTRY: ghcr.io
+  CONTAINER_REPO: ${{ github.repository }}
+
+permissions: read-all
+
+jobs:
+  delete:
+    # we don't want to mess up with forks for now
+    if: github.repository == 'inspektor-gadget/inspektor-gadget'
+    name: Branch delete
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: Setup go
+      uses: actions/setup-go@v5
+      with:
+        go-version: ${{ env.GO_VERSION }}
+        cache: true
+      id: go
+    - name: Set container repository and determine image tag
+      id: set-repo-determine-image-tag
+      uses: ./.github/actions/set-container-repo-and-determine-image-tag
+      with:
+        registry: ${{ env.REGISTRY }}
+        container-image: ${{ env.CONTAINER_REPO }}
+    - name: Cleanup citest- tags
+      run: |
+        cd tools/packagescleanup
+        go build .
+        ./packagescleanup ${{ github.repository_owner }} ${{ steps.set-repo-determine-image-tag.outputs.image-tag }}

--- a/tools/packagescleanup/.gitignore
+++ b/tools/packagescleanup/.gitignore
@@ -1,0 +1,1 @@
+packagescleanup

--- a/tools/packagescleanup/go.mod
+++ b/tools/packagescleanup/go.mod
@@ -1,0 +1,8 @@
+module packagescleanup
+
+go 1.21.4
+
+require (
+	github.com/google/go-github/v57 v57.0.0 // indirect
+	github.com/google/go-querystring v1.1.0 // indirect
+)

--- a/tools/packagescleanup/go.sum
+++ b/tools/packagescleanup/go.sum
@@ -1,0 +1,6 @@
+github.com/google/go-cmp v0.5.2/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
+github.com/google/go-github/v57 v57.0.0 h1:L+Y3UPTY8ALM8x+TV0lg+IEBI+upibemtBD8Q9u7zHs=
+github.com/google/go-github/v57 v57.0.0/go.mod h1:s0omdnye0hvK/ecLvpsGfJMiRt85PimQh4oygmLIxHw=
+github.com/google/go-querystring v1.1.0 h1:AnCroh3fv4ZBgVIf1Iwtovgjaw/GiKJo8M8yD/fhyJ8=
+github.com/google/go-querystring v1.1.0/go.mod h1:Kcdr2DB4koayq7X8pmAG4sNG59So17icRSOU623lUBU=
+golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=

--- a/tools/packagescleanup/main.go
+++ b/tools/packagescleanup/main.go
@@ -1,0 +1,125 @@
+// Copyright 2023 The Inspektor Gadget authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+	"os"
+	"strings"
+
+	"github.com/google/go-github/v57/github"
+)
+
+type pkgsInterface interface {
+	ListPackages(ctx context.Context, user string, opts *github.PackageListOptions) ([]*github.Package, *github.Response, error)
+	PackageGetAllVersions(ctx context.Context, username, packageType, packageName string, opts *github.PackageListOptions) ([]*github.PackageVersion, *github.Response, error)
+	PackageDeleteVersion(ctx context.Context, username, packageType, packageName string, packageVersionID int64) (*github.Response, error)
+}
+
+func cleanUpTag(client *github.Client, ctx context.Context, username, tag string) error {
+	if !strings.HasPrefix(tag, "citest-") {
+		return fmt.Errorf("tag %q doesn't start with citest-", tag)
+
+	}
+
+	var service pkgsInterface
+	user, _, err := client.Users.Get(ctx, username)
+	if err != nil {
+		return fmt.Errorf("getting user: %w", err)
+	}
+
+	switch *user.Type {
+	case "User":
+		service = client.Users
+	case "Organization":
+		service = client.Organizations
+	default:
+		return fmt.Errorf("invalid user type: %s", *user.Type)
+	}
+
+	container := "container"
+	active := "active"
+
+	opts := &github.PackageListOptions{
+		PackageType: &container,
+		State:       &active,
+	}
+
+	packages, _, err := service.ListPackages(ctx, username, opts)
+	if err != nil {
+		return fmt.Errorf("listing packages: %w", err)
+	}
+
+	for _, p := range packages {
+		if p.Name == nil {
+			continue
+		}
+
+		escapedName := url.QueryEscape(*p.Name)
+
+		opts := &github.PackageListOptions{
+			State: &active,
+		}
+		versions, _, err := service.PackageGetAllVersions(ctx, username, "container", escapedName, opts)
+		if err != nil {
+			return fmt.Errorf("getting package versions: %w", err)
+		}
+
+		for _, version := range versions {
+			if version.Metadata == nil || version.Metadata.Container == nil {
+				continue
+			}
+
+			for _, t := range version.Metadata.Container.Tags {
+				if t != tag {
+					continue
+				}
+
+				fmt.Printf("removing tag %q in repo %q\n", t, *p.Name)
+
+				_, err := service.PackageDeleteVersion(ctx, username, "container", escapedName, *version.ID)
+				if err != nil {
+					return fmt.Errorf("removing package version: %s", err)
+				}
+
+				fmt.Printf("removed: %s\n", t)
+			}
+		}
+	}
+
+	return nil
+}
+
+func main() {
+	if len(os.Args) < 3 {
+		fmt.Printf("usage: %s username tag\n", os.Args[0])
+		return
+	}
+
+	client := github.NewClient(nil)
+
+	client.WithAuthToken(os.Getenv("TOKEN"))
+
+	ctx := context.Background()
+
+	userName := os.Args[1]
+	tagToRemove := os.Args[2]
+
+	if err := cleanUpTag(client, ctx, userName, tagToRemove); err != nil {
+		fmt.Printf("error cleaning tags: %s\n", err)
+	}
+}


### PR DESCRIPTION
d496f48943b5 ("gha: Run AKS and ARO integration tests for citest/ branches too.") added a way to run the full CI tests on branches named citest/**. This implies building the container images and pushing them to the container registry. The logic to remove those container tags was missing.

This commit uses a GoLang program to clean those tags.

# [Title: describe the change in one sentence]

[ describe the change in 1 - 3 paragraphs ]

## How to use

[ describe what reviewers need to do in order to validate this PR ]

## Testing done

[Describe the testing you have done before submitting this PR. Please include both the commands you issued as well as the output you got.]
