### PR TITLE
ci: Avoid pulling gadget builder image multiple times

### DIFF
--- a/cmd/common/image/build.go
+++ b/cmd/common/image/build.go
@@ -375,6 +375,11 @@ func isImageLocallyAvailable(ctx context.Context, cli *client.Client, imageRefer
 				return true, nil
 			}
 		}
+		for _, digest := range img.RepoDigests {
+			if digest == imageReference {
+				return true, nil
+			}
+		}
 	}
 	return false, nil
 }

--- a/docs/reference/manifests.mdx
+++ b/docs/reference/manifests.mdx
@@ -83,6 +83,7 @@ image: trace_exec
 name: my-gadget-1
 paramValues:
   operator.LocalManager.host: true
+  operator.filter.filter: 'proc.comm~^ba.*$'
 tags:
   - mytag1
   - mytag2

--- a/docs/reference/run.mdx
+++ b/docs/reference/run.mdx
@@ -142,6 +142,16 @@ The filter syntax supports the following operations:
 - `field~value`: Matches if the content of `field` matches the regular expression `value`. See [RE2 Syntax](https://github.com/google/re2/wiki/Syntax) for more details.
 ```
 
+:::info
+
+It's recommended to wrap the **entire** filter expression with single quotes when using filters containing special characters to avoid unexpected behavior:
+
+```bash
+--filter 'proc.comm~^ba.*$'
+```
+
+:::
+
 #### Examples
 
 **Equal filter**: To filter events where the `comm` field equals `cat`, use:

--- a/docs/spec/operators/filter.md
+++ b/docs/spec/operators/filter.md
@@ -30,6 +30,24 @@ The filter syntax supports the following operations:
 - `field<value`: Matches if the content of `field` is less than `value`.
 - `field~value`: Matches if the content of `field` matches the regular expression `value`. See [RE2 Syntax](https://github.com/google/re2/wiki/Syntax) for more details.
 
+:::info
+
+It's recommended to wrap the **entire** filter expression with single quotes when using filters containing special characters to avoid unexpected behavior.
+
+[CLI](../../reference/run.mdx) example:
+
+```bash
+--filter 'proc.comm~^ba.*$'
+```
+
+[Gadget instance manifest](../../reference/manifests.mdx) example:
+
+```yaml
+operator.filter.filter: 'proc.comm~^ba.*$'
+```
+
+:::
+
 Fully qualified name: `operator.filter.filter`
 
 ### multiple filters

--- a/gadgets/Makefile
+++ b/gadgets/Makefile
@@ -64,18 +64,26 @@ GADGETS_README_DEV = $(filter-out ci/%, $(addsuffix /dev.md, $(GADGETS)))
 .PHONY: all
 all: build
 
+.PHONY: build
 build: $(GADGETS)
+
+# Pull the gadget builder in an independent step to avoid doing the same for
+# each gadget, which introduces some overhead and increases the build time.
+.PHONY: pull-builder-image
+pull-builder-image:
+	docker pull $(BUILDER_IMAGE)
 
 # GADGET_BUILD_PARAMS can be used to pass additional parameters e.g
 # GADGET_BUILD_PARAMS="--update-metadata" make build
 .PHONY: $(GADGETS)
-$(GADGETS):
+$(GADGETS): pull-builder-image
 	@echo "Building $@"
 	@sudo -E \
 		IG_SOURCE_PATH=$(realpath $(ROOT_DIR)/..) \
 		$(IG) image build \
 		--builder-image $(BUILDER_IMAGE) \
 		-t $(GADGET_REPOSITORY)/$@:$(GADGET_TAG) \
+		--builder-image-pull=never \
 		$$GADGET_BUILD_PARAMS \
 		$@
 


### PR DESCRIPTION
ig tries to pull the gadget builder for each gadget it compiles. It's inefficient and introduces a lot of delay when building multiple gadgets. Change the approach to only pull the image once.

# [Title: describe the change in one sentence]

[ describe the change in 1 - 3 paragraphs ]

## How to use

[ describe what reviewers need to do in order to validate this PR ]

## Testing done

[Describe the testing you have done before submitting this PR. Please include both the commands you issued as well as the output you got.]
