### PR TITLE
ci: Fix key calculation for gadget-builder-image cache

### DIFF
--- a/.github/workflows/inspektor-gadget.yml
+++ b/.github/workflows/inspektor-gadget.yml
@@ -989,7 +989,10 @@ jobs:
             context: "/home/runner/work/inspektor-gadget/inspektor-gadget"
             dockerfile: "Dockerfiles/gadget-builder.Dockerfile"
             platform: "linux/amd64,linux/arm64"
-            key-files: "'include/**','Dockerfiles/gadget-builder.Dockerfile','cmd/common/image/Makefile.build'"
+            key-files: |
+              include/**
+              Dockerfiles/gadget-builder.Dockerfile
+              cmd/common/image/Makefile.build
     steps:
     - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
     - name: Set up Docker Buildx


### PR DESCRIPTION
Fixes: f438ace21f5c ("ci: Enable cache for building helper images")

# [Title: describe the change in one sentence]

[ describe the change in 1 - 3 paragraphs ]

## How to use

[ describe what reviewers need to do in order to validate this PR ]

## Testing done

[Describe the testing you have done before submitting this PR. Please include both the commands you issued as well as the output you got.]
